### PR TITLE
fix: make sure handlers in useDisclosure are memoized

### DIFF
--- a/src/hooks/useDisclosure/useDisclosure.ts
+++ b/src/hooks/useDisclosure/useDisclosure.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 
 /**
  * Manages boolean state. It provides open, close and toggle handlers and accepts optional onOpen and onClose callbacks. It can be used to manage controlled modals, popovers and other similar components.
@@ -12,24 +12,24 @@ export const useDisclosure = (
 ): UseDisclosureReturn => {
   const [isOpen, setIsOpen] = useState(initialState)
 
-  const open = (): void => {
-    if (!isOpen) {
-      setIsOpen(true)
-      callbacks?.onOpen?.()
-    }
-  }
+  const open = useCallback(() => {
+    setIsOpen((_isOpen) => {
+      if (!_isOpen) callbacks?.onOpen?.()
+      return true
+    })
+  }, [callbacks])
 
-  const close = (): void => {
-    if (isOpen) {
-      setIsOpen(false)
-      callbacks?.onClose?.()
-    }
-  }
+  const close = useCallback(() => {
+    setIsOpen((_isOpen) => {
+      if (_isOpen) callbacks?.onClose?.()
+      return false
+    })
+  }, [callbacks])
 
-  const toggle = (): void => {
+  const toggle = useCallback(() => {
     if (isOpen) close()
     else open()
-  }
+  }, [close, isOpen, open])
 
   return { isOpen, handlers: { open, close, toggle } }
 }


### PR DESCRIPTION
We had a use case in saga admin where we had a method from the `useDisclosure` hook as a dependency in a useEffect, something like this:

  ```
useEffect(() => {
      setNavbarActions(
        <SecondaryButton onClick={handlers.open}>
          {t("pages.organizations.updateOrganization")}
        </SecondaryButton>,
      )
    }
    return () => {
      setNavbarActions(null)
    }
  }, [handlers.open, setNavbarActions, t])
```

Due to the hook not having a `useCallback` on it's methods, they were not memoized and thus triggered a rerun of the effect on every re-render. This PR takes care of this and makes sure the callbacks are never redefined