### PR TITLE
feat: change all `main` branch references to `master`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,10 +3,10 @@ name: CodeQL
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   schedule:
     - cron: 39 14 * * 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
       - beta
       - alpha
       - next

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -3,7 +3,7 @@ name: Review
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   review:

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   branches: [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "main",
+    "master",
     "next",
     "next-major",
     { name: "beta", prerelease: true },

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ yarn add @einride/hooks
 
 Import the hook you want to use from `@einride/hooks` and start using it!
 
-Take a look in the [hooks folder](https://github.com/einride/hooks/tree/main/src/hooks) to see
+Take a look in the [hooks folder](https://github.com/einride/hooks/tree/master/src/hooks) to see
 available hooks.
 
 ## Contribute
 
-See [Contributing Guide](https://github.com/einride/hooks/blob/main/CONTRIBUTING.md).
+See [Contributing Guide](https://github.com/einride/hooks/blob/master/CONTRIBUTING.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reusable React hooks",
   "scripts": {
     "build": "rollup --config",
-    "commitlint": "commitlint --from origin/main --to HEAD",
+    "commitlint": "commitlint --from origin/master --to HEAD",
     "format": "prettier --write .",
     "format-check": "prettier --check .",
     "lint": "eslint --ext .ts .",


### PR DESCRIPTION
`main` branch was moved to `master` instead to fall in line with the
rest of the organization
