### PR TITLE
chore: use node version 22 for release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Review
         run: yarn review


### PR DESCRIPTION
Since we set node version to be >22, release CI/CD also need to use the same version of node. Missed this part in the previous PR: https://github.com/einride/hooks/pull/694